### PR TITLE
Add support of positional/keyword only functions and improve @configurable_dependency

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -93,6 +93,14 @@ based on provided arguments to them:
   Also, :code:`configurable_dependency` decorator does not cache dependencies configured with mutable arguments.
 
 
+To check whether dependency is configured by @configurable_dependency use ``is_configured(call)`` function:
+
+.. literalinclude:: ../examples/configurable_check.py
+
+
+To get dependency configuration use ``get_configuration(call)`` function:
+
+.. literalinclude:: ../examples/configurable_config.py
 
 Composite dependencies
 ======================

--- a/docs/howtos/configurable-dependency.rst
+++ b/docs/howtos/configurable-dependency.rst
@@ -21,3 +21,17 @@ Composite dependencies - special kind of configurable dependency that accepts ot
 dependencies as parameters
 
 .. literalinclude:: ../../examples/composite_dependency.py
+
+
+Dependency configuration
+========================
+When a configurable dependency is called, FunDI stores its configuration,
+so third-party tools (e.g. routers, docs generators, validators) can extract the metadata.
+
+To check whether dependency is configured - use ``is_configured(call)`` function:
+
+.. literalinclude:: ../../examples/configurable_check.py
+
+To get dependency configuration - use ``get_configuration(call)`` function:
+
+.. literalinclude:: ../../examples/configurable_config.py

--- a/examples/configurable_check.py
+++ b/examples/configurable_check.py
@@ -1,0 +1,9 @@
+from fundi import is_configured, configurable_dependency
+
+
+@configurable_dependency
+def auth(optional: bool = False):
+    return lambda: optional
+
+
+assert is_configured(auth())

--- a/examples/configurable_config.py
+++ b/examples/configurable_config.py
@@ -1,0 +1,16 @@
+import inspect
+
+from fundi import get_configuration, configurable_dependency
+
+
+@configurable_dependency
+def auth(optional: bool = False):
+    return lambda: optional
+
+
+config = get_configuration(auth())
+
+origin = inspect.unwrap(auth)
+
+assert config.configurator.call == origin
+assert config.values == {"optional": False}

--- a/examples/keyword_only.py
+++ b/examples/keyword_only.py
@@ -1,0 +1,22 @@
+from contextlib import ExitStack
+
+from fundi import scan, inject
+
+
+def application(*, app_name: str, token: str) -> int:
+    if app_name == "Kat":
+        return 1
+
+    if token == "KatToken":
+        return 1
+
+    print(f'[{app_name}] user "{token}" logged in')
+    return 0
+
+
+with ExitStack() as stack:
+    exit_code = inject(
+        {"app_name": "Application name", "token": "f5a7f859-8d0c-42b8-bc72-b7ea9ade0519"},
+        scan(application),
+        stack,
+    )

--- a/examples/positional_only.py
+++ b/examples/positional_only.py
@@ -1,0 +1,24 @@
+from contextlib import ExitStack
+
+from fundi import scan, inject
+
+
+def application(app_name: str, token: str, /) -> int:
+    if app_name == "Kat":
+        return 1
+
+    if token == "KatToken":
+        return 1
+
+    print(f'[{app_name}] user "{token}" logged in')
+    return 0
+
+
+with ExitStack() as stack:
+    exit_code = inject(
+        {"app_name": "Application name", "token": "f5a7f859-8d0c-42b8-bc72-b7ea9ade0519"},
+        scan(application),
+        stack,
+    )
+
+    assert exit_code == 0, "Exit code != 0"

--- a/fundi/__init__.py
+++ b/fundi/__init__.py
@@ -5,10 +5,10 @@ from .from_ import from_
 from . import exceptions
 from .resolve import resolve
 from .debug import tree, order
-from .util import injection_trace
 from .inject import inject, ainject
-from .types import CallableInfo, TypeResolver, InjectionTrace, R, Parameter
+from .util import injection_trace, is_configured, get_configuration
 from .configurable import configurable_dependency, MutableConfigurationWarning
+from .types import CallableInfo, TypeResolver, InjectionTrace, R, Parameter, DependencyConfiguration
 
 
 FromType: _typing.TypeAlias = _typing.Annotated[R, TypeResolver]
@@ -26,8 +26,11 @@ __all__ = [
     "exceptions",
     "CallableInfo",
     "TypeResolver",
+    "is_configured",
     "InjectionTrace",
     "injection_trace",
+    "get_configuration",
+    "DependencyConfiguration",
     "configurable_dependency",
     "MutableConfigurationWarning",
 ]

--- a/fundi/scan.py
+++ b/fundi/scan.py
@@ -22,6 +22,8 @@ def scan(call: typing.Callable[..., R], caching: bool = True) -> CallableInfo[R]
                     param.name,
                     param.annotation,
                     from_=typing.cast(CallableInfo[typing.Any], param.default),
+                    positional_only=param.kind == inspect.Parameter.POSITIONAL_ONLY,
+                    keyword_only=param.kind == inspect.Parameter.KEYWORD_ONLY,
                 )
             )
             continue
@@ -49,6 +51,8 @@ def scan(call: typing.Callable[..., R], caching: bool = True) -> CallableInfo[R]
                 default=param.default if has_default else None,
                 has_default=has_default,
                 resolve_by_type=resolve_by_type,
+                positional_only=param.kind == inspect.Parameter.POSITIONAL_ONLY,
+                keyword_only=param.kind == inspect.Parameter.KEYWORD_ONLY,
             )
         )
 

--- a/fundi/types.py
+++ b/fundi/types.py
@@ -2,6 +2,7 @@ import typing
 import collections
 import collections.abc
 from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 __all__ = ["R", "TypeResolver", "Parameter", "CallableInfo", "ParameterResult", "InjectionTrace"]
 
@@ -28,6 +29,8 @@ class Parameter:
     default: typing.Any = None
     has_default: bool = False
     resolve_by_type: bool = False
+    positional_only: bool = False
+    keyword_only: bool = False
 
 
 @dataclass
@@ -37,6 +40,57 @@ class CallableInfo(typing.Generic[R]):
     async_: bool
     generator: bool
     parameters: list[Parameter]
+    named_parameters: dict[str, Parameter] = field(init=False)
+
+    def __post_init__(self):
+        self.named_parameters = {p.name: p for p in self.parameters}
+
+    def build_values(self, *args: typing.Any, **kwargs: typing.Any) -> dict[str, typing.Any]:
+        arguments: dict[str, typing.Any] = {}
+
+        args_amount = len(args)
+
+        ix = 0
+        for parameter in self.parameters:
+            name = parameter.name
+
+            if name in kwargs:
+                arguments[name] = kwargs[name]
+                continue
+
+            if ix < args_amount:
+                arguments[name] = args[ix]
+                ix += 1
+                continue
+
+            if parameter.has_default:
+                arguments[name] = parameter.default
+                continue
+
+            raise ValueError(f'Argument for parameter "{parameter.name}" not found')
+
+        return arguments
+
+    def build_arguments(
+        self, values: collections.abc.Mapping[str, typing.Any]
+    ) -> tuple[tuple[typing.Any, ...], dict[str, typing.Any]]:
+        positional: tuple[typing.Any, ...] = ()
+        keyword: dict[str, typing.Any] = {}
+
+        for name, value in values.items():
+            if name not in self.named_parameters:
+                raise ValueError(f'Parameter named "{name}" not found')
+
+            parameter = self.named_parameters[name]
+
+            if parameter.positional_only:
+                positional += (value,)
+            elif parameter.keyword_only:
+                keyword[name] = value
+            else:
+                positional += (value,)
+
+        return positional, keyword
 
 
 @dataclass

--- a/fundi/types.py
+++ b/fundi/types.py
@@ -1,10 +1,17 @@
 import typing
 import collections
 import collections.abc
-from dataclasses import dataclass
 from dataclasses import dataclass, field
 
-__all__ = ["R", "TypeResolver", "Parameter", "CallableInfo", "ParameterResult", "InjectionTrace"]
+__all__ = [
+    "R",
+    "Parameter",
+    "TypeResolver",
+    "CallableInfo",
+    "InjectionTrace",
+    "ParameterResult",
+    "DependencyConfiguration",
+]
 
 R = typing.TypeVar("R")
 
@@ -106,3 +113,9 @@ class InjectionTrace:
     info: CallableInfo[typing.Any]
     values: collections.abc.Mapping[str, typing.Any]
     origin: "InjectionTrace | None" = None
+
+
+@dataclass
+class DependencyConfiguration:
+    configurator: CallableInfo[typing.Any]
+    values: collections.abc.Mapping[str, typing.Any]

--- a/fundi/util.py
+++ b/fundi/util.py
@@ -5,14 +5,16 @@ import collections.abc
 from types import TracebackType
 from contextlib import AsyncExitStack, ExitStack
 
-from fundi.types import CallableInfo, InjectionTrace
+from fundi.types import CallableInfo, InjectionTrace, DependencyConfiguration
 
 
 __all__ = [
     "call_sync",
     "call_async",
     "callable_str",
+    "is_configured",
     "injection_trace",
+    "get_configuration",
     "add_injection_trace",
 ]
 
@@ -159,3 +161,27 @@ def injection_trace(exception: Exception) -> InjectionTrace:
         raise ValueError(f"Exception {exception} does not contain injection trace")
 
     return typing.cast(InjectionTrace, getattr(exception, "__fundi_injection_trace__"))
+
+
+def is_configured(call: typing.Callable[..., typing.Any]) -> bool:
+    """
+    Get whether callable is configured via @configurable_dependency
+
+    :param call: callable to check
+    :return: Is this callable configured
+    """
+    return hasattr(call, "__fundi_configuration__")
+
+
+def get_configuration(call: typing.Callable[..., typing.Any]) -> DependencyConfiguration:
+    """
+    Get dependency configuration. Can be useful in third-party tools that needs to know configuration
+
+    :param call: callable to get configuration from
+    :return: dependency configuration
+    """
+    if not is_configured(call):
+        raise ValueError(f"Callable {call} is not configured via @configurable_dependency")
+
+    configuration: DependencyConfiguration = getattr(call, "__fundi_configuration__")
+    return configuration

--- a/fundi/util.py
+++ b/fundi/util.py
@@ -57,7 +57,8 @@ def call_sync(
     :param values: callable arguments
     :return: callable result
     """
-    value = info.call(**values)
+    args, kwargs = info.build_arguments(values)
+    value = info.call(*args, **kwargs)
 
     if info.generator:
         generator: collections.abc.Generator[typing.Any, None, None] = value
@@ -106,7 +107,9 @@ async def call_async(
     :param values: callable arguments
     :return: callable result
     """
-    value = info.call(**values)
+    args, kwargs = info.build_arguments(values)
+
+    value = info.call(*args, **kwargs)
 
     if info.generator:
         generator: collections.abc.AsyncGenerator[typing.Any] = value

--- a/tests/inject/test_inject.py
+++ b/tests/inject/test_inject.py
@@ -183,3 +183,23 @@ def test_dependency_parameter_awareness():
 
     with ExitStack() as stack:
         inject({}, scan(func), stack)
+
+
+def test_positional_only():
+    def dep(arg: str, /):
+        return arg
+
+    with ExitStack() as stack:
+        result = inject({"arg": "argValue"}, scan(dep), stack)
+
+        assert result == "argValue"
+
+
+def test_keyword_only():
+    def dep(*, arg: str):
+        return arg
+
+    with ExitStack() as stack:
+        result = inject({"arg": "argValue"}, scan(dep), stack)
+
+        assert result == "argValue"

--- a/tests/scan/test_scan.py
+++ b/tests/scan/test_scan.py
@@ -1,3 +1,4 @@
+import inspect
 from fundi import scan, from_, FromType
 from fundi.types import Parameter
 
@@ -129,3 +130,27 @@ def test_scan_FromType():
     assert info.generator is False
     assert info.call is dep
     assert info.parameters == [Parameter("arg", Session, None, resolve_by_type=True)]
+
+
+def test_scan_positional_only():
+    def dep(arg: str, /): ...
+
+    info = scan(dep)
+
+    assert info.async_ is False
+    assert info.generator is False
+    assert info.call is dep
+    assert info.parameters == [
+        Parameter("arg", str, None, positional_only=True),
+    ]
+
+
+def test_scan_keyword_only():
+    def dep(*, arg: str): ...
+
+    info = scan(dep)
+
+    assert info.async_ is False
+    assert info.generator is False
+    assert info.call is dep
+    assert info.parameters == [Parameter("arg", str, None, keyword_only=True)]

--- a/tests/test_configurable_dependency.py
+++ b/tests/test_configurable_dependency.py
@@ -1,6 +1,9 @@
+import functools
+import inspect
 import warnings
 
 from fundi import configurable_dependency, MutableConfigurationWarning
+from fundi.util import get_configuration, is_configured
 
 
 def test_configurable_dependency_caching():
@@ -12,9 +15,20 @@ def test_configurable_dependency_caching():
 
     assert factory() is factory()
     assert factory(require_admin=True) is not factory()
-    assert factory(require_admin=False) is not factory()
+    assert factory(require_admin=False) is factory()
     assert factory(require_admin=True) is factory(require_admin=True)
     assert factory(require_admin=False) is factory(require_admin=False)
+
+    dependency = factory()
+
+    assert is_configured(dependency)
+
+    config = get_configuration(dependency)
+
+    origin = inspect.unwrap(factory)
+    assert config.configurator.call is origin
+
+    assert config.values == {"require_admin": False}
 
 
 def test_configurable_dependency_mutable_argument():
@@ -31,3 +45,13 @@ def test_configurable_dependency_mutable_argument():
 
     assert got_warnings
     assert got_warnings[0].category is MutableConfigurationWarning
+
+    dependency = factory(("permission",))
+    assert is_configured(dependency)
+
+    config = get_configuration(dependency)
+
+    origin = inspect.unwrap(factory)
+    assert config.configurator.call is origin
+
+    assert config.values == {"permissions": ("permission",)}


### PR DESCRIPTION
This PR add support injection of functions with positional/keyword only parameters.

Also, it improves developer experience in using `@configurable_dependency` decorator by adding `is_configured(call)` and `get_configuration(call)` functions that can be used to determine whether dependency is configured and get its configuration. Useful for third-party tools that may be used in couple with FunDI