### PR TITLE
Add return type to CallableInfo and preserve Annotated instance on creating parameters list

### DIFF
--- a/fundi/resolve.py
+++ b/fundi/resolve.py
@@ -37,8 +37,16 @@ def resolve_by_type(
     type_options = (annotation,)
 
     origin = typing.get_origin(annotation)
+    args = typing.get_args(annotation)
+
+    if origin is typing.Annotated:
+        annotation = args[0]
+        type_options = (annotation,)
+        origin = typing.get_origin(annotation)
+        args = typing.get_args(annotation)
+
     if origin is types.UnionType:
-        type_options = tuple(t for t in typing.get_args(annotation) if t is not None)
+        type_options = tuple(t for t in args if t is not None)
     elif origin is not None:
         type_options = (origin,)
 

--- a/fundi/scan.py
+++ b/fundi/scan.py
@@ -14,8 +14,9 @@ def scan(call: typing.Callable[..., R], caching: bool = True) -> CallableInfo[R]
     :return: callable information
     """
     params: list[Parameter] = []
+    signature = inspect.signature(call)
 
-    for param in inspect.signature(call).parameters.values():
+    for param in signature.parameters.values():
         positional_only = param.kind == inspect.Parameter.POSITIONAL_ONLY
         keyword_only = param.kind == inspect.Parameter.KEYWORD_ONLY
         if isinstance(param.default, CallableInfo):
@@ -64,7 +65,12 @@ def scan(call: typing.Callable[..., R], caching: bool = True) -> CallableInfo[R]
     info = typing.cast(
         CallableInfo[R],
         CallableInfo(
-            call=call, use_cache=caching, async_=async_, generator=generator, parameters=params
+            call=call,
+            use_cache=caching,
+            async_=async_,
+            generator=generator,
+            parameters=params,
+            return_annotation=signature.return_annotation,
         ),
     )
 

--- a/fundi/scan.py
+++ b/fundi/scan.py
@@ -34,14 +34,13 @@ def scan(call: typing.Callable[..., R], caching: bool = True) -> CallableInfo[R]
         has_default = param.default is not inspect.Parameter.empty
         resolve_by_type = False
 
-        annotation: type = param.annotation
+        annotation = param.annotation
         if isinstance(annotation, TypeResolver):
             annotation = annotation.annotation
             resolve_by_type = True
 
         elif typing.get_origin(annotation) is typing.Annotated:
             args = typing.get_args(annotation)
-            annotation = args[0]
 
             if args[1] is TypeResolver:
                 resolve_by_type = True

--- a/fundi/types.py
+++ b/fundi/types.py
@@ -47,7 +47,7 @@ class CallableInfo(typing.Generic[R]):
     async_: bool
     generator: bool
     parameters: list[Parameter]
-    return_annotation: R
+    return_annotation: typing.Any
     named_parameters: dict[str, Parameter] = field(init=False)
 
     def __post_init__(self):

--- a/fundi/types.py
+++ b/fundi/types.py
@@ -31,7 +31,7 @@ class TypeResolver:
 @dataclass
 class Parameter:
     name: str
-    annotation: type
+    annotation: typing.Any
     from_: "CallableInfo[typing.Any] | None"
     default: typing.Any = None
     has_default: bool = False

--- a/fundi/types.py
+++ b/fundi/types.py
@@ -47,6 +47,7 @@ class CallableInfo(typing.Generic[R]):
     async_: bool
     generator: bool
     parameters: list[Parameter]
+    return_annotation: R
     named_parameters: dict[str, Parameter] = field(init=False)
 
     def __post_init__(self):

--- a/tests/scan/test_scan.py
+++ b/tests/scan/test_scan.py
@@ -129,7 +129,7 @@ def test_scan_FromType():
     assert info.async_ is False
     assert info.generator is False
     assert info.call is dep
-    assert info.parameters == [Parameter("arg", Session, None, resolve_by_type=True)]
+    assert info.parameters == [Parameter("arg", FromType[Session], None, resolve_by_type=True)]
 
 
 def test_scan_positional_only():


### PR DESCRIPTION
This PR changes behavior of `fundi.scan.scan` function - with this change Parameter object now preserve original Annotated object in annotation attribute. This change provide more convenient way to integrate third-party tools with this library.

Also, CallableInfo now stores information about return types of original callable