### PR TITLE
Add configuration into CallableInfo

### DIFF
--- a/fundi/scan.py
+++ b/fundi/scan.py
@@ -1,6 +1,7 @@
 import typing
 import inspect
 
+from fundi.util import is_configured, get_configuration
 from fundi.types import R, CallableInfo, Parameter, TypeResolver
 
 
@@ -70,6 +71,7 @@ def scan(call: typing.Callable[..., R], caching: bool = True) -> CallableInfo[R]
             generator=generator,
             parameters=params,
             return_annotation=signature.return_annotation,
+            configuration=get_configuration(call) if is_configured(call) else None,
         ),
     )
 

--- a/fundi/types.py
+++ b/fundi/types.py
@@ -48,6 +48,7 @@ class CallableInfo(typing.Generic[R]):
     generator: bool
     parameters: list[Parameter]
     return_annotation: typing.Any
+    configuration: "DependencyConfiguration | None"
     named_parameters: dict[str, Parameter] = field(init=False)
 
     def __post_init__(self):

--- a/uv.lock
+++ b/uv.lock
@@ -182,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "fundi"
-version = "1.1.5"
+version = "1.1.6"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
This PR adds `configuration` attribute to CallableInfo that can be used to get dependency configuration created by `fundi.configurable.configurable_dependency` decorator