### PR TITLE
Fix ``build_arguments`` for a positional arguments

### DIFF
--- a/fundi/types.py
+++ b/fundi/types.py
@@ -114,11 +114,13 @@ class CallableInfo(typing.Generic[R]):
         positional: tuple[typing.Any, ...] = ()
         keyword: dict[str, typing.Any] = {}
 
-        for name, value in values.items():
-            if name not in self.named_parameters:
-                raise ValueError(f'Parameter named "{name}" not found')
+        for parameter in self.parameters:
+            name = parameter.name
 
-            parameter = self.named_parameters[name]
+            if name not in values:
+                raise ValueError(f'Value for "{name}" parameter not found')
+
+            value = values[name]
 
             if parameter.positional_only:
                 positional += (value,)

--- a/tests/misc/test_build_arguments.py
+++ b/tests/misc/test_build_arguments.py
@@ -1,0 +1,56 @@
+from fundi import scan
+
+
+def test_default():
+    def dep(arg: int, arg2: str): ...
+
+    info = scan(dep)
+
+    args, kwargs = info.build_arguments({"arg": 1, "arg2": "1"})
+
+    assert args == (1, "1")
+    assert kwargs == {}
+
+
+def test_posonly():
+    def dep(arg: int, /, arg2: str): ...
+
+    info = scan(dep)
+
+    args, kwargs = info.build_arguments({"arg": 1, "arg2": "1"})
+
+    assert args == (1, "1")
+    assert kwargs == {}
+
+
+def test_kwonly():
+    def dep(arg: int, *, arg2: str): ...
+
+    info = scan(dep)
+
+    args, kwargs = info.build_arguments({"arg": 1, "arg2": "1"})
+
+    assert args == (1,)
+    assert kwargs == {"arg2": "1"}
+
+
+def test_varargs():
+    def dep(*args: int | str): ...
+
+    info = scan(dep)
+
+    args, kwargs = info.build_arguments({"args": (1, "1")})
+
+    assert args == (1, "1")
+    assert kwargs == {}
+
+
+def test_varkw():
+    def dep(**args: int | str): ...
+
+    info = scan(dep)
+
+    args, kwargs = info.build_arguments({"args": {"arg": 1, "arg2": "1"}})
+
+    assert args == ()
+    assert kwargs == {"arg": 1, "arg2": "1"}

--- a/tests/misc/test_build_values.py
+++ b/tests/misc/test_build_values.py
@@ -1,0 +1,51 @@
+from fundi import scan
+
+
+def test_default():
+    def dep(arg: int, arg2: str): ...
+
+    info = scan(dep)
+
+    values = info.build_values(arg=1, arg2="1")
+
+    assert values == {"arg": 1, "arg2": "1"}
+
+
+def test_posonly():
+    def dep(arg: int, /, arg2: str): ...
+
+    info = scan(dep)
+
+    values = info.build_values(arg=1, arg2="1")
+
+    assert values == {"arg": 1, "arg2": "1"}
+
+
+def test_kwonly():
+    def dep(arg: int, *, arg2: str): ...
+
+    info = scan(dep)
+
+    values = info.build_values(1, "1")
+
+    assert values == {"arg": 1, "arg2": "1"}
+
+
+def test_varargs():
+    def dep(*args: int | str): ...
+
+    info = scan(dep)
+
+    values = info.build_values(1, "1")
+
+    assert values == {"args": (1, "1")}
+
+
+def test_varkw():
+    def dep(**args: int | str): ...
+
+    info = scan(dep)
+
+    values = info.build_values(arg=1, arg2="1")
+
+    assert values == {"args": {"arg": 1, "arg2": "1"}}


### PR DESCRIPTION
Replace ``build_arguments`` iteration through ``values`` to iteration through parameters. This fixes issue with building positional arguments - positional arguments may be in incorrect order if the ``values`` dictionary is in incorrect order