### PR TITLE
Add overriding and typehint inference into fundi.scan.scan()

### DIFF
--- a/fundi/from_.py
+++ b/fundi/from_.py
@@ -6,7 +6,12 @@ from fundi.types import CallableInfo, TypeResolver
 
 
 def from_(
-    dependency: type | typing.Callable[..., typing.Any], caching: bool = True
+    dependency: type | typing.Callable[..., typing.Any],
+    caching: bool = True,
+    async_: bool | None = None,
+    generator: bool | None = None,
+    context: bool | None = None,
+    use_return_annotation: bool = True,
 ) -> TypeResolver | CallableInfo[typing.Any]:
     """
     Use callable or type as dependency for parameter of function
@@ -24,4 +29,11 @@ def from_(
     ):
         return TypeResolver(dependency)
 
-    return scan(dependency, caching=caching)
+    return scan(
+        dependency,
+        caching=caching,
+        async_=async_,
+        generator=generator,
+        context=context,
+        use_return_annotation=use_return_annotation,
+    )

--- a/fundi/from_.pyi
+++ b/fundi/from_.pyi
@@ -8,21 +8,57 @@ R = typing.TypeVar("R")
 
 @overload
 def from_(
-    dependency: typing.Callable[..., AbstractContextManager[R]], caching: bool = True
+    dependency: typing.Callable[..., AbstractContextManager[R]],
+    caching: bool = True,
+    async_: bool | None = None,
+    generator: bool | None = None,
+    context: bool | None = None,
+    use_return_annotation: bool = True,
 ) -> R: ...
 @overload
 def from_(
-    dependency: typing.Callable[..., AbstractAsyncContextManager[R]], caching: bool = True
+    dependency: typing.Callable[..., AbstractAsyncContextManager[R]],
+    caching: bool = True,
+    async_: bool | None = None,
+    generator: bool | None = None,
+    context: bool | None = None,
+    use_return_annotation: bool = True,
 ) -> R: ...
 @overload
 def from_(dependency: T, caching: bool = True) -> T: ...
 @overload
 def from_(
-    dependency: typing.Callable[..., Generator[R, None, None]], caching: bool = True
+    dependency: typing.Callable[..., Generator[R, None, None]],
+    caching: bool = True,
+    async_: bool | None = None,
+    generator: bool | None = None,
+    context: bool | None = None,
+    use_return_annotation: bool = True,
 ) -> R: ...
 @overload
-def from_(dependency: typing.Callable[..., AsyncGenerator[R, None]], caching: bool = True) -> R: ...
+def from_(
+    dependency: typing.Callable[..., AsyncGenerator[R, None]],
+    caching: bool = True,
+    async_: bool | None = None,
+    generator: bool | None = None,
+    context: bool | None = None,
+    use_return_annotation: bool = True,
+) -> R: ...
 @overload
-def from_(dependency: typing.Callable[..., Awaitable[R]], caching: bool = True) -> R: ...
+def from_(
+    dependency: typing.Callable[..., Awaitable[R]],
+    caching: bool = True,
+    async_: bool | None = None,
+    generator: bool | None = None,
+    context: bool | None = None,
+    use_return_annotation: bool = True,
+) -> R: ...
 @overload
-def from_(dependency: typing.Callable[..., R], caching: bool = True) -> R: ...
+def from_(
+    dependency: typing.Callable[..., R],
+    caching: bool = True,
+    async_: bool | None = None,
+    generator: bool | None = None,
+    context: bool | None = None,
+    use_return_annotation: bool = True,
+) -> R: ...

--- a/fundi/scan.py
+++ b/fundi/scan.py
@@ -2,9 +2,10 @@ import typing
 import inspect
 from dataclasses import replace
 from types import BuiltinFunctionType, FunctionType, MethodType
+from collections.abc import AsyncGenerator, Awaitable, Generator
 from contextlib import AbstractAsyncContextManager, AbstractContextManager
 
-from fundi.util import is_configured, get_configuration
+from fundi.util import is_configured, get_configuration, normalize_annotation
 from fundi.types import R, CallableInfo, Parameter, TypeResolver
 
 
@@ -67,12 +68,22 @@ def _is_async_context(call: typing.Any):
         return isinstance(call, AbstractAsyncContextManager)
 
 
-def scan(call: typing.Callable[..., R], caching: bool = True) -> CallableInfo[R]:
+def scan(
+    call: typing.Callable[..., R],
+    caching: bool = True,
+    async_: bool | None = None,
+    generator: bool | None = None,
+    context: bool | None = None,
+    use_return_annotation: bool = True,
+) -> CallableInfo[R]:
     """
     Get callable information
 
     :param call: callable to get information from
     :param caching:  whether to use cached result of this callable or not
+    :param async_: Override "async_" attriubute value
+    :param generator: Override "generator" attriubute value
+    :param context: Override "context" attriubute value
 
     :return: callable information
     """
@@ -92,15 +103,37 @@ def scan(call: typing.Callable[..., R], caching: bool = True) -> CallableInfo[R]
 
     signature = inspect.signature(truecall)
 
-    generator = inspect.isgeneratorfunction(truecall)
-    async_generator = inspect.isasyncgenfunction(truecall)
+    return_ = type
+    if signature.return_annotation is not signature.empty:
+        return_ = normalize_annotation(signature.return_annotation)[0]
 
-    context = _is_context(call)
-    async_context = _is_async_context(call)
+    # WARNING: over-engineered logic!! :3
 
-    async_ = inspect.iscoroutinefunction(truecall) or async_generator or async_context
-    generator = generator or async_generator
-    context = context or async_context
+    _generator: bool = inspect.isgeneratorfunction(truecall)
+    _agenerator: bool = inspect.isasyncgenfunction(truecall)
+    _context: bool = _is_context(call)
+    _acontext: bool = _is_async_context(call)
+
+    # Getting "generator" using return typehint or __code__ flags
+    if generator is None:
+        generator = (
+            use_return_annotation
+            and (issubclass(return_, Generator) or issubclass(return_, AsyncGenerator))
+        ) or (_generator or _agenerator)
+
+    # Getting "context" using return typehint or callable type
+    if context is None:
+        context = (
+            use_return_annotation
+            and (issubclass(return_, (AbstractContextManager, AbstractAsyncContextManager)))
+        ) or (_context or _acontext)
+
+    # Getting "async_" using return typehint or __code__ flags or defined above variables
+    if async_ is None:
+        async_ = (
+            use_return_annotation
+            and issubclass(return_, (AsyncGenerator, AbstractAsyncContextManager, Awaitable))
+        ) or (_agenerator or _acontext or inspect.iscoroutinefunction(truecall))
 
     parameters = [_transform_parameter(parameter) for parameter in signature.parameters.values()]
 

--- a/fundi/scan.py
+++ b/fundi/scan.py
@@ -90,7 +90,18 @@ def scan(
 
     if hasattr(call, "__fundi_info__"):
         info = typing.cast(CallableInfo[typing.Any], getattr(call, "__fundi_info__"))
-        return replace(info, use_cache=caching)
+
+        overrides = {"use_cache": caching}
+        if async_ is not None:
+            overrides["async_"] = async_
+
+        if generator is not None:
+            overrides["generator"] = generator
+
+        if context is not None:
+            overrides["context"] = context
+
+        return replace(info, **overrides)
 
     if not callable(call):
         raise ValueError(

--- a/tests/scan/test_scan.py
+++ b/tests/scan/test_scan.py
@@ -268,3 +268,94 @@ def test_scan_varkw():
     info = scan(dep)
 
     assert info.parameters == [Parameter("kwargs", int, None, keyword_varying=True)]
+
+
+def test_scan_override_context():
+    import contextlib
+
+    @contextlib.contextmanager
+    def dep():
+        yield None
+
+    info = scan(dep, context=True)
+
+    assert info.context is True
+
+
+def test_scan_override_async():
+    import asyncio
+
+    def dep():
+        return asyncio.Future()
+
+    info = scan(dep, async_=True)
+
+    assert info.async_ is True
+
+
+def test_scan_override_generator():
+    def generator():
+        yield 1
+
+    def dep():
+        return generator()
+
+    info = scan(dep, generator=True)
+
+    assert info.generator is True
+
+
+def test_scan_infer_context():
+    import contextlib
+
+    def dep() -> contextlib.AbstractContextManager: ...
+
+    info = scan(dep)
+
+    assert info.context is True
+
+    def dep() -> contextlib.AbstractAsyncContextManager: ...
+
+    info = scan(dep)
+
+    assert info.context is True
+
+
+def test_scan_infer_generator():
+    import collections.abc as C
+
+    def dep() -> C.Generator: ...
+
+    info = scan(dep)
+
+    assert info.generator is True
+
+    def dep() -> C.AsyncGenerator: ...
+
+    info = scan(dep)
+
+    assert info.generator is True
+
+
+def test_scan_infer_generator():
+    import asyncio
+    import contextlib
+    import collections.abc as C
+
+    def dep() -> asyncio.Future: ...
+
+    info = scan(dep)
+
+    assert info.async_ is True
+
+    def dep() -> contextlib.AbstractAsyncContextManager: ...
+
+    info = scan(dep)
+
+    assert info.async_ is True
+
+    def dep() -> C.AsyncGenerator: ...
+
+    info = scan(dep)
+
+    assert info.async_ is True


### PR DESCRIPTION
This PR improves FunDIs scan of the dependencies by allowing to override CallableInfo attributes inside the call of the ``scan()`` and ``from_()``. Also, it adds attribute inferring by the function's return type-hint.