### PR TITLE
Add support of defining dependencies using ``typing.Annotated``

### DIFF
--- a/docs/howtos/dependant.rst
+++ b/docs/howtos/dependant.rst
@@ -3,7 +3,8 @@ Dependant
 *********
 
 A dependant is any Python function that declares its dependencies by
-setting parameter defaults to :code:`from_(...)`. They also can be used as dependencies.
+setting parameter defaults to :code:`from_(...)`. They also can be used as dependencies and 
+be asynchronous as any other dependency.
 
   Note: By default, each dependency is evaluated only once
   per injection cycle — subsequent uses are cached.
@@ -65,7 +66,9 @@ You may want to wrap several dependencies together
         print(f"Using username {username} to hack into your wife's Instagram")
 
 
-Asynchronous dependant:
+Asynchronous dependants work the same as the synchronous ones.
+The key difference is that they are **asynchronous** (Of course!) and
+FunDI will ``await`` them when needed.
 
 .. code-block:: python
 
@@ -78,6 +81,23 @@ Asynchronous dependant:
     async def application(user: User = from_(require_user)):
         print(f"Current user is {user}")
 
-..
 
-  Async dependants works exactly the same - FunDI will :code:`await` them when needed.
+Dependants can define dependencies inside a positional parameter using the ``typing.Annotated`` type-hint.
+
+This may be used to keep logical order of the dependencies inside dependant, or ensure that 
+type-checker would not display false warning:
+
+.. code-block:: python
+
+    from typing import Annotated
+
+    from fundi import from_ 
+
+
+    def require_int() -> int:
+        return 1
+
+
+    def application(value: Annotated[int, from_(require_int)]):
+        print(f"Resolved {value = }")
+

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -19,3 +19,10 @@ Mixed
 You can mix async and sync dependencies using :code:`ainject` function
 
 .. literalinclude:: ../examples/mixed.py
+
+
+Positional dependencies
+=======================
+You may want to define dependencies inside a positional parameter. To do so, you need to use ``typing.Annotated`` in pair of ``from_()``
+
+.. literalinclude:: ../examples/positional_dependency.py

--- a/examples/positional_dependency.py
+++ b/examples/positional_dependency.py
@@ -1,0 +1,16 @@
+from contextlib import ExitStack
+from typing import Annotated
+
+from fundi import from_, inject, scan
+
+
+def require_int() -> int:
+    return 255
+
+
+def application(value: Annotated[int, from_(require_int)], scope_value: str):
+    print(f"Application started with {value = } and {scope_value = !r}")
+
+
+with ExitStack() as stack:
+    inject({"scope_value": "17/03/2026"}, scan(application), stack)

--- a/tests/scan/test_scan.py
+++ b/tests/scan/test_scan.py
@@ -369,3 +369,16 @@ def test_scan_with_None_typehint():
     assert info.async_ is False
     assert info.generator is False
     assert info.context is False
+
+
+def test_scan_Annotated_dependency():
+    from typing import Annotated
+
+    def dep() -> int: ...
+
+    def dependant(value: Annotated[int, from_(dep)]): ...
+
+    info = scan(dependant)
+
+    assert info.parameters[0].from_ is not None
+    assert info.parameters[0].from_.call is dep


### PR DESCRIPTION
This PR adds new supported syntax of defining dependencies - using ``typing.Annotated``

### Example
```python
from fundi import from_ 

from typing import Annotated

def require_int() -> int:
    return 1


def application(value: Annotated[int, from_(require_int)]): ...
```