### PR TITLE
Add hook that is called when dependency is defined in dependant

### DIFF
--- a/fundi/hooks.py
+++ b/fundi/hooks.py
@@ -1,0 +1,22 @@
+import typing
+
+from fundi.scan import scan as scan_
+from fundi.types import CallableInfo, Parameter
+
+R = typing.TypeVar("R")
+C = typing.TypeVar("C", bound=typing.Callable[..., typing.Any])
+
+
+def with_hooks(
+    graph: typing.Callable[[CallableInfo[R], Parameter], CallableInfo[R] | None] | None = None,
+):
+    def applier(call: C) -> C:
+        info = scan_(call)
+
+        info.graphhook = graph
+
+        setattr(call, "__fundi_info__", info)
+
+        return call
+
+    return applier

--- a/fundi/scan.py
+++ b/fundi/scan.py
@@ -41,7 +41,7 @@ def _transform_parameter(parameter: inspect.Parameter) -> Parameter:
             if presence:
                 from_ = presence[0]
 
-    return Parameter(
+    parameter_ = Parameter(
         parameter.name,
         annotation,
         from_=from_,
@@ -53,6 +53,14 @@ def _transform_parameter(parameter: inspect.Parameter) -> Parameter:
         keyword_varying=keyword_varying,
         keyword_only=keyword_only,
     )
+
+    if from_ is not None and from_.graphhook is not None:
+        from_ = from_.graphhook(from_, parameter_)
+
+        if from_ is not None:
+            return replace(parameter_, from_=from_)
+
+    return parameter_
 
 
 def _is_context(call: typing.Any):

--- a/fundi/types.py
+++ b/fundi/types.py
@@ -56,6 +56,10 @@ class CallableInfo(typing.Generic[R]):
     named_parameters: dict[str, Parameter] = field(init=False)
     key: "CacheKey" = field(init=False)
 
+    graphhook: typing.Callable[["CallableInfo[R]", Parameter], "CallableInfo[R] | None"] | None = (
+        None
+    )
+
     def __post_init__(self):
         self.named_parameters = {p.name: p for p in self.parameters}
         self.key = CacheKey(self.call)


### PR DESCRIPTION
Adds hook that can be used to modify dependency at the usage point.

Example
```python
import typing

from fundi.hooks import with_hooks
from fundi import CallableInfo, Parameter, FromType, from_

from webkat.http import Request


# Modifies dependency's cache key to include parameter name 
def cache_hook(ci: CallableInfo[typing.Any], parameter: Parameter):
    ci.key.add(parameter.name)
    return ci


@with_hooks(cache_hook)
def dependency(request: Request, parameter: FromType[Parameter]):
    return request.headers[parameter.name].first()


def endpoint(x_token: str = from_(dependency)): ...

```